### PR TITLE
Upgraded mongodb to 2.2.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/dial-once/node-mongoat#readme",
   "dependencies": {
     "lodash": "4.0.0",
-    "mongodb": "2.1.4"
+    "mongodb": "2.2.25"
   },
   "devDependencies": {
     "codacy-coverage": "^1.1.3",


### PR DESCRIPTION
Upgraded to the latest mongodb since the currently used one is deprecated.

> npm WARN deprecated mongodb@2.1.4: Please upgrade to 2.2.19 or higher
